### PR TITLE
Fix build on Linux when `libc++` is present

### DIFF
--- a/tree_sitter/__init__.py
+++ b/tree_sitter/__init__.py
@@ -1,8 +1,8 @@
 """Python bindings for tree-sitter."""
 
 from ctypes import cdll, c_void_p
-from ctypes.util import find_library
 from distutils.ccompiler import new_compiler
+from distutils.unixccompiler import UnixCCompiler
 from os import path
 from platform import system
 from tempfile import TemporaryDirectory
@@ -43,11 +43,8 @@ class Language:
         ]
 
         compiler = new_compiler()
-        if cpp:
-            if find_library("c++"):
-                compiler.add_library("c++")
-            elif find_library("stdc++"):
-                compiler.add_library("stdc++")
+        if isinstance(compiler, UnixCCompiler):
+            compiler.compiler_cxx[0] = "c++"
 
         if max(source_mtimes) <= output_mtime:
             return False
@@ -69,7 +66,11 @@ class Language:
                         extra_preargs=flags,
                     )[0]
                 )
-            compiler.link_shared_object(object_paths, output_path)
+            compiler.link_shared_object(
+                object_paths,
+                output_path,
+                target_lang="c++" if cpp else "c",
+            )
         return True
 
     def __init__(self, library_path, name):


### PR DESCRIPTION
When a tree sitter grammar contains a `scanner.cc` file, a C++ standard
library must be linked to the final grammar shared object. `distutils`
uses the default `cc` compiler driver to compile and link C and C++
files. On Linux, this is GCC, so `libstdc++` must be linked, even if
`libc++` is present.

On Mac, `libc++` is the default, even if `libstdc++` is present.

Use the `c++` compiler driver, so that the appropriate standard library
is selected automatically.